### PR TITLE
Adjust harakiri signal configuration

### DIFF
--- a/app/harakiri/apps.py
+++ b/app/harakiri/apps.py
@@ -10,5 +10,5 @@ class HarakiriConfig(AppConfig):
     name = "harakiri"
 
     def ready(self) -> None:
-        signal.signal(signal.SIGSYS, HarakiriLoggerMiddleware.handle_signal)
+        signal.signal(signal.SIGHUP, HarakiriLoggerMiddleware.handle_signal)
         return super().ready()

--- a/app/harakiri/middleware.py
+++ b/app/harakiri/middleware.py
@@ -2,7 +2,6 @@ import logging
 import uuid
 from collections.abc import Callable
 from threading import local
-
 from django import http
 
 logger = logging.getLogger("APP-MIDDLEWARE")
@@ -13,17 +12,64 @@ class HarakiriLoggerMiddleware:
 
     @classmethod
     def handle_signal(cls, *args: object) -> None:
-        tid, path = getattr(cls._locals, "request_info", (None, None))
-        if tid is None or path is None:
+        """
+        Handle the SIGHUP (=1) signal sent by uWSGI when it's about to kill the process.
+        This allows us to log the request details before we see a harakiri event.
+        """
+        tid, request = getattr(cls._locals, "request_info", (None, None))
+        if tid is None or request is None:
             logger.info("No request info found")
             return
-        logger.error(f"Harakiri signal received: {tid=} {path=}")
+
+        # Log the request before the process encounters a graceful shutdown.
+        cls._log_harakiri_event(request)
 
     def __init__(self, get_response: Callable) -> None:
         self.get_response = get_response
 
     def __call__(self, request: http.HttpRequest) -> http.response.HttpResponseBase:
         t_id = uuid.uuid4()
-        path = request.path
-        self._locals.request_info = (t_id, path)
+        self._locals.request_info = (t_id, request)
+
+        import signal
+
+        logger.info(f"signal handlers: {signal.getsignal(signal.SIGHUP)}")
+
         return self.get_response(request)
+
+    def _log_harakiri_event(self, request: http.HttpRequest) -> None:
+        """
+        Attempt to log the request before the process is gracefully killed.
+        """
+        logger.error(f"Harakiri signal received: {request.path=}")
+        logger.error("Logging here before graceful shutdown...")
+
+        # TODO: Set up instrumentation to log the request to Datadog. This is a placeholder.
+        # The below code is just an example of how we might log the request to DD.
+
+        # import ddtrace
+        # from ddtrace import constants as ddtrace_constants
+        # from ddtrace.contrib.django import utils as ddtrace_django_utils
+        # from django import http
+
+        # root_span = ddtrace.tracer.current_root_span()
+        # if root_span is not None:
+        #     root_span.error = 1
+        #     root_span.set_tag_str(ddtrace_constants.ERROR_MSG, "uWSGI graceful shutdown")
+        #     root_span.set_tag_str(ddtrace_constants.ERROR_TYPE, "uWSGI timeout")
+
+        #     ddtrace_django_utils._after_request_tags(
+        #         # Pin isn't used in `_after_request_tags` so we don't pass one. Am not sure how to
+        #         # load/find the appropriate pin object anyhow.
+        #         pin=None,
+        #         span=root_span,
+        #         request=request,
+        #         # This response won't actually be returned by the application, but this is what a
+        #         # reverse proxy like Nginx will return if the application doesn't respond in time,
+        #         # which is the typical behaviour when uWSGI kills the process.
+        #         response=http.HttpResponse(status=504),
+        #     )
+
+        # current_span = ddtrace.tracer.current_span()
+        # if current_span is not None:
+        #     current_span.finish_with_ancestors()

--- a/app/uwsgi.conf
+++ b/app/uwsgi.conf
@@ -11,9 +11,9 @@ single-interpreter      = true
 http = 0.0.0.0:8000
 module                  = app.wsgi:application
 
-harakiri = 8
+harakiri = 5
 harakiri-verbose = true
 lazy-apps = true
-harakiri-graceful-timeout = 5
+harakiri-graceful-timeout = 3
 harakiri-graceful-signal = 1
 py-call-osafterfork = true

--- a/app/uwsgi.conf
+++ b/app/uwsgi.conf
@@ -11,9 +11,9 @@ single-interpreter      = true
 http = 0.0.0.0:8000
 module                  = app.wsgi:application
 
-harakiri = 5
+harakiri = 8
 harakiri-verbose = true
 lazy-apps = true
 harakiri-graceful-timeout = 5
-harakiri-graceful-signal = 31
+harakiri-graceful-signal = 1
 py-call-osafterfork = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-uwsgi==2.0.24
+uwsgi==2.0.26
 django==4.2
 ruff==0.1
 ipython==8.20


### PR DESCRIPTION
Why is this still not working?! This builds on the harakiri graceful handling experiment by:
- Bumping uwsgi version to 2.0.26, which apparently resolves the problem with multithreaded workers
- Adjust the harakiri graceful signal to SIGHUP (=1) which is recommended for graceful shutdown
- Testing some slight changes to the middleware


References:
https://github.com/DataDog/dd-trace-py/issues/3792
https://github.com/unbit/uwsgi/issues/2614
https://github.com/getsentry/sentry-python/discussions/1783
https://github.com/unbit/uwsgi/pull/2523/files
https://github.com/unbit/uwsgi/pull/2311

Also see Slack thread [here](https://krakentech.slack.com/archives/C05T5QHKZKK/p1722404712489929?thread_ts=1718317802.618399&cid=C05T5QHKZKK)